### PR TITLE
conditionally parse as jsx

### DIFF
--- a/src/parse.spec.ts
+++ b/src/parse.spec.ts
@@ -4,13 +4,13 @@ import { findFirst } from './ast-helpers';
 
 describe('parseTs', () => {
   it('should always set the isScriptSetup property to false', () => {
-    const ast = parseTs('const a = 1 + 1');
+    const ast = parseTs('const a = 1 + 1', false);
 
     expect(ast.isScriptSetup).toBe(false);
   });
 
   it('should parse jsx', () => {
-    const ast = parseTs('const btn = () => <button>Hello</button>');
+    const ast = parseTs('const btn = () => <button>Hello</button>', true);
     expect(findFirst(ast, { type: 'JSXElement' })).not.toBeNull();
   });
 });

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -179,7 +179,7 @@ function transformTypescriptFile(
   filename: string,
   codemods: CodemodPlugin[],
 ): TransformResult {
-  const ast = parseTs(code);
+  const ast = parseTs(code, /\.[jt]sx$/.test(filename));
   const stats: [string, number][] = [];
 
   for (const codemod of codemods) {


### PR DESCRIPTION
since jsx syntax can conflict with some typescript syntax, only parse as jsx if:

- the file extension is jsx / tsx
- `<script lang="jsx">` / `<script lang="tsx">`