### PR TITLE
breaking: update plugin apis

### DIFF
--- a/docs/guide/manual-migrations.md
+++ b/docs/guide/manual-migrations.md
@@ -17,13 +17,13 @@ import { ManualMigrationPlugin } from 'vue-metamorph';
 const migrateVueEmitter: ManualMigrationPlugin = {
   type: 'manual',
   name: 'Migrate vue event emitter',
-  find(
+  find({
     scriptASTs,
-    templateAST,
+    sfcAST,
     filename,
     report,
-    { traverseScriptAST }
-  ) {
+    utils: { traverseScriptAST }
+  }) {
     for (const scriptAST of scriptASTs) {
       traverseScriptAST(scriptAST, {
         visitCallExpression(path) {

--- a/docs/guide/writing-codemods.md
+++ b/docs/guide/writing-codemods.md
@@ -2,7 +2,7 @@
 
 ## Basics
 
-In a nutshell, a vue-metamorph codemod is a function that you define, which is passed two ASTs - the script AST, and the template AST. Your function can traverse and mutate these ASTs, and vue-metamorph will detect your changes and apply them to your source code file.
+In a nutshell, a vue-metamorph codemod is a function that you define, which is passed two ASTs - the script AST, and the template AST. Your function can traverse and mutate these ASTs by changing properties, or adding/removing nodes, and vue-metamorph will detect your changes and apply them to your source code file.
 
 In a `.js` or `.ts` file, the template AST will always be null.
 
@@ -17,7 +17,7 @@ const changeStringLiterals: CodemodPlugin = {
   type: 'codemod',
   name: 'change string literals to hello, world',
 
-  transform(scriptASTs, templateAST, filename, { traverseScriptAST, traverseTemplateAST }) {
+  transform({ scriptASTs, sfcAST, filename, utils: { traverseScriptAST, traverseTemplateAST } }) {
     // codemod plugins self-report the number of transforms it made
     // this is only used to print the stats in CLI output
     let transformCount = 0;
@@ -41,10 +41,10 @@ const changeStringLiterals: CodemodPlugin = {
       });
     }
 
-    if (templateAST) {
+    if (sfcAST) {
       // traverseTemplateAST is an alias for the vue-eslint-parser 'AST.traverseNodes' function
       // see: https://github.com/vuejs/vue-eslint-parser/blob/master/src/ast/traverse.ts#L118
-      traverseTemplateAST(templateAST, {
+      traverseTemplateAST(sfcAST, {
         enterNode(node) {
           if (node.type === 'Literal' && typeof node.value === 'string') {
             // mutate the node
@@ -70,7 +70,7 @@ Codemods can choose which files to operate on using the `filename` parameter. Fo
 
 ```ts
 const codemod = {
-  transform(scriptASTs, templateAST, filename) {
+  transform({ filename }) {
     if (!/\.spec\.[jt]s/g.test(filename)) {
       return;
     }

--- a/src/ast-helpers.spec.ts
+++ b/src/ast-helpers.spec.ts
@@ -7,9 +7,9 @@ describe('createDefaultImport', () => {
   const codemod: CodemodPlugin = {
     type: 'codemod',
     name: '',
-    transform(scriptAST) {
-      if (scriptAST[0]) {
-        astHelpers.createDefaultImport(scriptAST[0], 'vue', 'Vue');
+    transform({ scriptASTs }) {
+      if (scriptASTs[0]) {
+        astHelpers.createDefaultImport(scriptASTs[0], 'vue', 'Vue');
       }
 
       return 1;
@@ -67,9 +67,9 @@ describe('createNamedImport', () => {
   const codemod: CodemodPlugin = {
     type: 'codemod',
     name: '',
-    transform(scriptAST) {
-      if (scriptAST[0]) {
-        astHelpers.createNamedImport(scriptAST[0], 'vue', 'defineComponent');
+    transform({ scriptASTs }) {
+      if (scriptASTs[0]) {
+        astHelpers.createNamedImport(scriptASTs[0], 'vue', 'defineComponent');
       }
 
       return 1;

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,12 +1,19 @@
 import * as Kinds from 'ast-types/gen/kinds';
+import { builders as scriptBuilders } from 'ast-types';
 import * as templateBuilders from './builders';
 import * as AST from './ast';
 
+/**
+ * AST Node builders
+ * @public
+ */
+const builders = {
+  ...scriptBuilders,
+  ...templateBuilders,
+};
+
 export {
-  /**
-   * Utility functions for building new Vue \<template\> AST Nodes
-   */
-  templateBuilders,
+  builders,
 };
 
 export {
@@ -18,7 +25,6 @@ export {
 
 export {
   namedTypes,
-  builders as scriptBuilders,
   visit as traverseScriptAST,
 } from 'ast-types';
 
@@ -44,6 +50,8 @@ export type {
   CodemodPlugin,
   ManualMigrationPlugin,
   VueProgram,
+  CodemodPluginContext,
+  ManualMigrationPluginContext,
 } from './types.js';
 
 export type {

--- a/src/manual.spec.ts
+++ b/src/manual.spec.ts
@@ -120,9 +120,11 @@ export default {
 </script>`, 'file.vue', [{
       name: 'test',
       type: 'manual',
-      find(scriptAST, templateAST, _filename, report, { astHelpers }) {
-        if (scriptAST[0]) {
-          const onCall = astHelpers.findFirst(scriptAST[0], {
+      find({
+        scriptASTs, sfcAST, report, utils: { astHelpers },
+      }) {
+        if (scriptASTs[0]) {
+          const onCall = astHelpers.findFirst(scriptASTs[0], {
             type: 'CallExpression',
             callee: {
               type: 'MemberExpression',
@@ -138,8 +140,8 @@ export default {
           }
         }
 
-        if (templateAST) {
-          const div = astHelpers.findFirst(templateAST, {
+        if (sfcAST) {
+          const div = astHelpers.findFirst(sfcAST, {
             type: 'VElement',
             rawName: 'div',
           });
@@ -201,7 +203,9 @@ console.log('')`,
       [{
         name: 'console-logs',
         type: 'manual',
-        find(scriptASTs, sfcAST, filename, report, utils) {
+        find({
+          scriptASTs, sfcAST, filename, report, utils,
+        }) {
           expect(sfcAST).toBeNull();
           expect(filename).toBe('file.js');
           expect(scriptASTs.length).toBe(1);
@@ -249,7 +253,9 @@ console.log('')`,
         [{
           name: 'console-logs',
           type: 'manual',
-          find(scriptASTs, sfcAST, filename, report, utils) {
+          find({
+            scriptASTs, sfcAST, filename, report, utils,
+          }) {
             expect(sfcAST).toBeNull();
             expect(filename).toBe('file.js');
             expect(scriptASTs.length).toBe(1);

--- a/src/manual.ts
+++ b/src/manual.ts
@@ -1,7 +1,7 @@
 import * as AST from './ast';
 import { parseTs, parseVue } from './parse';
 import {
-  ManualMigrationPlugin, ReportFunction, VueProgram, util,
+  ManualMigrationPlugin, ReportFunction, VueProgram, utils,
 } from './types';
 
 type SampleArgs = {
@@ -150,7 +150,7 @@ export function findManualMigrations(
   let template: AST.VDocumentFragment | null = null;
 
   if (filename.endsWith('.vue')) {
-    const { scriptAsts, vueAst } = parseVue(code);
+    const { scriptASTs: scriptAsts, sfcAST: vueAst } = parseVue(code);
     scripts = scriptAsts;
     template = vueAst.templateBody!.parent as AST.VDocumentFragment;
   } else {
@@ -187,7 +187,14 @@ export function findManualMigrations(
       throw new Error(`Node type ${node.type} is missing location information`);
     };
 
-    plugin.find(scripts, template, filename, report, util, opts);
+    plugin.find({
+      scriptASTs: scripts,
+      sfcAST: template,
+      filename,
+      report,
+      utils,
+      opts,
+    });
   }
 
   return reports;

--- a/src/parse.spec.ts
+++ b/src/parse.spec.ts
@@ -19,12 +19,12 @@ describe('parseVue', () => {
   it('should set isScriptSetup to true for <script setup>', () => {
     const ast = parseVue('<script setup>\nconst a = 1 + 1;\n</script>');
 
-    expect(ast.scriptAsts[0]?.isScriptSetup).toBe(true);
+    expect(ast.scriptASTs[0]?.isScriptSetup).toBe(true);
   });
 
   it('should set isScriptSetup to false for <script>', () => {
     const ast = parseVue('<script>\nexport default {}\n</script>');
-    expect(ast.scriptAsts[0]?.isScriptSetup).toBe(false);
+    expect(ast.scriptASTs[0]?.isScriptSetup).toBe(false);
   });
 
   it('should work with two <scripts>', () => {
@@ -38,12 +38,12 @@ describe('parseVue', () => {
       </script>
     `);
 
-    expect(ast.scriptAsts[0]?.isScriptSetup).toBe(false);
-    expect(ast.scriptAsts[1]?.isScriptSetup).toBe(true);
+    expect(ast.scriptASTs[0]?.isScriptSetup).toBe(false);
+    expect(ast.scriptASTs[1]?.isScriptSetup).toBe(true);
   });
 
   it('should parse jsx', () => {
     const ast = parseVue('<script setup lang="jsx">\nconst btn = () => <button>Hello</button>\n</script>');
-    expect(findFirst(ast.scriptAsts[0]!, { type: 'JSXElement' })).not.toBeNull();
+    expect(findFirst(ast.scriptASTs[0]!, { type: 'JSXElement' })).not.toBeNull();
   });
 });

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -104,17 +104,17 @@ export function parseVue(code: string) {
     code += '\n<template></template>';
   }
 
-  const vueAst = vueParser.parse(code, {
+  const sfcAST = vueParser.parse(code, {
     parser: tsParser(true),
     sourceType: 'module',
   });
 
-  const scripts = findAll(vueAst.templateBody!.parent as VDocumentFragment, {
+  const scripts = findAll(sfcAST.templateBody!.parent as VDocumentFragment, {
     type: 'VElement',
     name: 'script',
   }) as vueParser.AST.VElement[];
 
-  const scriptAsts = scripts.map((el) => {
+  const scriptASTs = scripts.map((el) => {
     // hack: make the source locations line up properly
     const blankLines = '\n'.repeat(el.loc.start.line - 1);
     const start = el.children[0]?.range[0];
@@ -132,8 +132,8 @@ export function parseVue(code: string) {
   });
 
   return {
-    vueAst,
-    scriptAsts,
+    sfcAST,
+    scriptASTs,
   };
 }
 

--- a/src/transform.spec.ts
+++ b/src/transform.spec.ts
@@ -40,21 +40,20 @@ export default defineComponent({
 const stringLiteralPlugin: CodemodPlugin = {
   name: 'test',
   type: 'codemod',
-  transform(
-    scripts,
-    template,
-    _filename,
-    {
-      traverseScriptAST, traverseTemplateAST, templateBuilders, astHelpers,
+  transform({
+    scriptASTs,
+    sfcAST,
+    utils: {
+      traverseScriptAST, traverseTemplateAST, builders, astHelpers,
     },
-  ) {
-    if (!template) {
+  }) {
+    if (!sfcAST) {
       return 0;
     }
 
     let count = 0;
 
-    for (const script of scripts) {
+    for (const script of scriptASTs) {
       traverseScriptAST(script, {
         visitProperty(path) {
           if (path.node.value.type === 'Literal'
@@ -66,12 +65,12 @@ const stringLiteralPlugin: CodemodPlugin = {
       });
     }
 
-    traverseTemplateAST(template, {
+    traverseTemplateAST(sfcAST, {
       enterNode(node) {
         if (node.type === 'VElement' && node.rawName === 'script') {
           node.startTag.attributes.push(
-            templateBuilders.vAttribute(
-              templateBuilders.vIdentifier('setup'),
+            builders.vAttribute(
+              builders.vIdentifier('setup'),
               null,
             ),
           );
@@ -83,8 +82,8 @@ const stringLiteralPlugin: CodemodPlugin = {
           node.rawName = 'strong';
 
           node.startTag.attributes.push(
-            templateBuilders.vAttribute(
-              templateBuilders.vIdentifier('hi'),
+            builders.vAttribute(
+              builders.vIdentifier('hi'),
               null,
             ),
           );
@@ -95,7 +94,7 @@ const stringLiteralPlugin: CodemodPlugin = {
       },
     });
 
-    astHelpers.findAll(template, {
+    astHelpers.findAll(sfcAST, {
       type: 'VElement',
       name: 'custom',
     })
@@ -165,7 +164,7 @@ describe('transform', () => {
     const codemod: CodemodPlugin = {
       type: 'codemod',
       name: 'test',
-      transform(scriptASTs, _sfcAST, _filename, utils) {
+      transform({ scriptASTs, utils }) {
         let count = 0;
         for (const scriptAST of scriptASTs) {
           utils.astHelpers.findAll(scriptAST, {

--- a/template/package.json
+++ b/template/package.json
@@ -10,7 +10,7 @@
     "test": "vitest"
   },
   "dependencies": {
-    "vue-metamorph": "^2.1.2"
+    "vue-metamorph": "^3.0.0"
   },
   "devDependencies": {
     "@types/node": "^20.11.30",

--- a/template/src/plugins/hello-world.ts
+++ b/template/src/plugins/hello-world.ts
@@ -3,7 +3,7 @@ import { CodemodPlugin } from 'vue-metamorph';
 export const helloWorldCodemod: CodemodPlugin = {
   type: 'codemod',
   name: 'hello-world',
-  transform(scriptASTs, _templateAST, _filename, { traverseScriptAST, astHelpers }) {
+  transform({ scriptASTs, utils: { traverseScriptAST, astHelpers } }) {
     let transformCount = 0;
 
     for (const scriptAST of scriptASTs) {


### PR DESCRIPTION
breaking changes to prepare for updates:
- changes the `mutate()` and `find()` plugin APIs to pass a context object instead of a long list of arguments
- `scriptBuilders` and `templateBuilders` are now merged onto a single `builders` object