### PR TITLE
Add support for stylus

### DIFF
--- a/docs/guide/writing-codemods.md
+++ b/docs/guide/writing-codemods.md
@@ -92,7 +92,7 @@ The code printed by vue-metamorph will not be formatted perfectly. vue-metamorph
 
 ## CSS
 
-CSS codemods are supported as of vue-metamorph v3.1.0. Supported syntaxes include css, sass, scss, and less.
+CSS codemods are supported as of vue-metamorph v3.1.0. Supported syntaxes include css, sass, scss, less and stylus.
 
 Each codemod plugin will be passed an array of [PostCSS Root](https://postcss.org/api/#root) objects. Use the PostCSS API to make changes to the stylesheets.
 
@@ -110,12 +110,14 @@ Make sure to choose the correct parser:
 | Vue SFC `<style lang="scss">` | `postcss` (parser=scss) |
 | Vue SFC `<style lang="sass">` | `postcss` (parser=sass) |
 | Vue SFC `<style lang="less">` | `postcss` (parser=less) |
+| Vue SFC `<style lang="stylus">` | Not supported |
 | JavaScript | `@babel/parser` |
 | TypeScript | `@babel/parser` |
 | CSS | `postcss` |
 | LESS | `postcss` (parser=less) |
 | SASS | `postcss` (parser=sass) |
 | SCSS | `postcss` (parser=scss) |
+| STYLUS | Not supported |
 
 When using `@babel/parser` with AST Explorer, enable [this list](https://github.com/UnrefinedBrain/vue-metamorph/blob/master/src/parse/typescript.ts#L15-L57) of plugins to get an accurate representation of the AST you'll be working with.
 

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "postcss-less": "^6.0.0",
     "postcss-sass": "^0.5.0",
     "postcss-scss": "^4.0.9",
+    "postcss-styl": "^0.12.3",
     "recast": "^0.23.6",
     "table": "^6.8.1",
     "vue-eslint-parser": "^9.4.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,9 @@ dependencies:
   postcss-scss:
     specifier: ^4.0.9
     version: 4.0.9(postcss@8.4.38)
+  postcss-styl:
+    specifier: ^0.12.3
+    version: 0.12.3
   recast:
     specifier: ^0.23.6
     version: 0.23.6
@@ -2000,6 +2003,12 @@ packages:
     engines: {node: '>=8'}
     dev: false
 
+  /atob@2.1.2:
+    resolution: {integrity: sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==}
+    engines: {node: '>= 4.5.0'}
+    hasBin: true
+    dev: false
+
   /available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
@@ -2201,6 +2210,14 @@ packages:
     engines: {node: '>= 6'}
     dev: false
 
+  /css@3.0.0:
+    resolution: {integrity: sha512-DG9pFfwOrzc+hawpmqX/dHYHJG+Bsdb0klhyi1sDneOgGOXy9wQIC8hzyVp1e4NRYDBdxcylvywPkkXCHAzTyQ==}
+    dependencies:
+      inherits: 2.0.4
+      source-map: 0.6.1
+      source-map-resolve: 0.6.0
+    dev: false
+
   /csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
     dev: true
@@ -2263,6 +2280,11 @@ packages:
     dependencies:
       character-entities: 2.0.2
     dev: true
+
+  /decode-uri-component@0.2.2:
+    resolution: {integrity: sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==}
+    engines: {node: '>=0.10'}
+    dev: false
 
   /deep-diff@1.0.2:
     resolution: {integrity: sha512-aWS3UIVH+NPGCD1kki+DCU9Dua032iSsO43LqQpcs4R3+dVv7tX0qBGjiVHJHjplsoUM2XRO/KB92glqc68awg==}
@@ -2784,6 +2806,10 @@ packages:
 
   /fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  /fast-diff@1.3.0:
+    resolution: {integrity: sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==}
+    dev: false
 
   /fast-glob@3.3.2:
     resolution: {integrity: sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==}
@@ -3459,6 +3485,10 @@ packages:
   /lodash.sortby@4.7.0:
     resolution: {integrity: sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==}
     dev: true
+
+  /lodash.sortedlastindex@4.1.0:
+    resolution: {integrity: sha512-s8xEQdsp2Tu5zUqVdFSe9C0kR8YlnAJYLqMdkh+pIRBRxF6/apWseLdHl3/+jv2I61dhPwtI/Ff+EqvCpc+N8w==}
+    dev: false
 
   /lodash.truncate@4.4.2:
     resolution: {integrity: sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==}
@@ -4205,6 +4235,19 @@ packages:
       postcss: 8.4.38
     dev: false
 
+  /postcss-styl@0.12.3:
+    resolution: {integrity: sha512-8I7Cd8sxiEITIp32xBK4K/Aj1ukX6vuWnx8oY/oAH35NfQI4OZaY5nd68Yx8HeN5S49uhQ6DL0rNk0ZBu/TaLg==}
+    engines: {node: ^8.10.0 || ^10.13.0 || ^11.10.1 || >=12.13.0}
+    dependencies:
+      debug: 4.3.4
+      fast-diff: 1.3.0
+      lodash.sortedlastindex: 4.1.0
+      postcss: 8.4.38
+      stylus: 0.57.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /postcss@8.4.38:
     resolution: {integrity: sha512-Wglpdk03BSfXkHoQa3b/oulrotAkwrlLDRSOb9D0bN86FdRyE9lppSp33aHNPgBa0JKCoB+drFLZkQoRRYae5A==}
     engines: {node: ^10 || ^12 || >=14}
@@ -4406,6 +4449,14 @@ packages:
       is-regex: 1.1.4
     dev: true
 
+  /safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+    dev: false
+
+  /sax@1.2.4:
+    resolution: {integrity: sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==}
+    dev: false
+
   /search-insights@2.13.0:
     resolution: {integrity: sha512-Orrsjf9trHHxFRuo9/rzm0KIWmgzE8RMlZMzuhZOJ01Rnz3D0YBAe+V6473t6/H6c7irs6Lt48brULAiRWb3Vw==}
     dev: true
@@ -4514,6 +4565,14 @@ packages:
     resolution: {integrity: sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==}
     engines: {node: '>=0.10.0'}
 
+  /source-map-resolve@0.6.0:
+    resolution: {integrity: sha512-KXBr9d/fO/bWo97NXsPIAW1bFSBOuCnjbNTBMO7N59hsv5i9yzRDfcYwwt0l04+VqnKC+EwzvJZIP/qkuMgR/w==}
+    deprecated: See https://github.com/lydell/source-map-resolve#deprecated
+    dependencies:
+      atob: 2.1.2
+      decode-uri-component: 0.2.2
+    dev: false
+
   /source-map@0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
@@ -4521,7 +4580,6 @@ packages:
   /source-map@0.7.4:
     resolution: {integrity: sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==}
     engines: {node: '>= 8'}
-    dev: true
 
   /source-map@0.8.0-beta.0:
     resolution: {integrity: sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==}
@@ -4631,6 +4689,20 @@ packages:
     dependencies:
       js-tokens: 8.0.3
     dev: true
+
+  /stylus@0.57.0:
+    resolution: {integrity: sha512-yOI6G8WYfr0q8v8rRvE91wbxFU+rJPo760Va4MF6K0I6BZjO4r+xSynkvyPBP9tV1CIEUeRsiidjIs2rzb1CnQ==}
+    hasBin: true
+    dependencies:
+      css: 3.0.0
+      debug: 4.3.4
+      glob: 7.2.3
+      safer-buffer: 2.1.2
+      sax: 1.2.4
+      source-map: 0.7.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
 
   /sucrase@3.35.0:
     resolution: {integrity: sha512-8EbVDiu9iN/nESwxeSxDKe0dunta1GOlHufmSSXxMD2z2/tMZpDMpvXQGsc+ajGo8y2uYUmixaSRUc/QPoQ0GA==}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -131,7 +131,7 @@ export function createVueMetamorphCli(options: CreateVueMetamorphCliOptions) {
             return true;
           }
 
-          if (!/\.(vue|ts|js|tsx|jsx|css|scss|less|sass)$/.test(p.fullpath())) {
+          if (!/\.(vue|ts|js|tsx|jsx|css|scss|less|sass|styl)$/.test(p.fullpath())) {
             return true;
           }
 

--- a/src/parse/css.ts
+++ b/src/parse/css.ts
@@ -2,12 +2,14 @@ import postcss from 'postcss';
 import postcssLess from 'postcss-less';
 import postcssSass from 'postcss-sass';
 import postcssScss from 'postcss-scss';
+import postcssStyl from 'postcss-styl';
 
 const syntaxMap: Record<string, typeof postcssScss> = {
   css: postcss,
   scss: postcssScss,
   less: postcssLess,
   sass: postcssSass,
+  stylus: postcssStyl,
 };
 
 export const getCssDialectForFilename = (filename: string) => {
@@ -16,6 +18,7 @@ export const getCssDialectForFilename = (filename: string) => {
     case filename.endsWith('.sass'): return 'sass';
     case filename.endsWith('.less'): return 'less';
     case filename.endsWith('.css'): return 'css';
+    case filename.endsWith('.styl'): return 'styl';
     default: return null;
   }
 };

--- a/src/transform.spec.ts
+++ b/src/transform.spec.ts
@@ -47,6 +47,12 @@ export default defineComponent({
   color: blue;
 }
 </style>
+
+<style lang="stylus">
+.className
+  $variable= 1234
+  color green
+</style>
 `;
 
 const stringLiteralPlugin: CodemodPlugin = {
@@ -184,6 +190,13 @@ describe('transform', () => {
         color: blue !important;
         background-color: black;
       }
+      </style>
+
+      <style lang="stylus">
+      .className{
+        $variable: 1234;
+        color: green !important;
+        background-color: black}
       </style>
       ",
         "stats": [

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -236,6 +236,7 @@ function transformCssFile(
     case filename.endsWith('.less'): dialect = 'less'; break;
     case filename.endsWith('.scss'): dialect = 'scss'; break;
     case filename.endsWith('.sass'): dialect = 'sass'; break;
+    case filename.endsWith('.styl'): dialect = 'stylus'; break;
     default:
   }
   const ast = parseCss(code, dialect);

--- a/src/types.ts
+++ b/src/types.ts
@@ -48,7 +48,7 @@ export type ManualMigrationPluginContext = {
 
   /**
    * If this is a .vue file, postcss contexts of each \<style\> block
-   * If this is a css/scss/less/sass file, the 0th element is the context of the file
+   * If this is a css/scss/less/sass/styl file, the 0th element is the context of the file
    */
   styleASTs: postcss.Root[];
 
@@ -105,7 +105,7 @@ export type CodemodPluginContext = {
 
   /**
    * If this is a .vue file, postcss contexts of each \<style\> block
-   * If this is a css/scss/less/sass file, the 0th element is the context of the file
+   * If this is a css/scss/less/sass/styl file, the 0th element is the context of the file
    */
   styleASTs: postcss.Root[];
 

--- a/src/types/postcss-styl.d.ts
+++ b/src/types/postcss-styl.d.ts
@@ -1,0 +1,6 @@
+declare module 'postcss-styl' {
+  import * as postcss from 'postcss';
+
+  export const parse: postcss.Parser<postcss.Root>;
+  export const stringify: postcss.Stringifier;
+}


### PR DESCRIPTION
Hello 👋 

Since you've added CSS support to vue-metamorph I cannot parse my codebase anymore, due to it using `<style lang="stylus">` 
I wouldn't mind that much if it just ignored those but it raises a parsing error. I figured I'd give it a try and the tests seem to work. Not sure how it would behave when parsing `.styl` files though, I get an error when trying to build (even master) 🤷‍♂️ 

Also, it looks like astexplorer does not parse stylus (at least the syntax I've added in the tests).
If this PR doesn't work as expected or if you don't want to bother with stylus (which I would understand), can I ask what would be needed to at least ignore `style` tags with unknown language ?

cheers, and thanks again for this tool, I'm looking forward to using vue-upgrade-tools 👍 