### PR TITLE
add support for parsing/printing html comments

### DIFF
--- a/docs/guide/writing-codemods.md
+++ b/docs/guide/writing-codemods.md
@@ -82,9 +82,11 @@ const codemod = {
 
 :::
 
-## Code Comment Preservation
+## HTML Code Comments
 
-Recast does a fairly decent job of preserving code comments in JavaScript and TypeScript, but at this time, HTML comments inside of modified `<template>` nodes will not be re-printed. Comments inside unchanged `<template>` nodes will not be affected.
+Certain `<template>` node types (`VExpressionContainer`, `VText`, `VStartTag`, `VEndTag`, `HtmlComment`) have a `leadingComment` property that contains a `HtmlComment` node that is attached to the node and will be printed directly prior to it.
+
+Note: a `VExpressionContainer`'s `leadingComment` will only be printed if the `VExpressionContainer` is a direct child of a `VElement`.
 
 ## Code Formatting
 

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -4,8 +4,9 @@ import { AST } from 'vue-eslint-parser';
 
 // Adapted from https://github.com/vuejs/vue-eslint-parser/blob/master/src/ast/nodes.ts
 
-// Removed HasLocation from types for better compatibility with builders
-// Also changed ESLint* types to namedTypes types
+// - Removed HasLocation from types for better compatibility with builders
+// - Changed ESLint* types to namedTypes types
+// - Added leadingComment property to some nodes
 
 /*
  * MIT License
@@ -35,6 +36,13 @@ import { AST } from 'vue-eslint-parser';
  */
 export interface HasParent {
   parent?: Node | null;
+}
+
+/**
+ * @public
+ */
+export interface HasLeadingComment {
+  leadingComment: HtmlComment | null;
 }
 
 /**
@@ -161,10 +169,19 @@ export type VNode =
  * Text nodes.
  * @public
  */
-export interface VText extends HasParent {
+export interface VText extends HasParent, HasLeadingComment {
   type: 'VText';
   parent: VDocumentFragment | VElement;
   value: string;
+}
+
+/**
+ * @public
+ */
+export interface HtmlComment extends HasLeadingComment {
+  type: 'HtmlComment';
+  value: string;
+  range: [number, number];
 }
 
 /**
@@ -172,7 +189,7 @@ export interface VText extends HasParent {
  * e.g. `{{ name }}`
  * @public
  */
-export interface VExpressionContainer extends HasParent {
+export interface VExpressionContainer extends HasParent, HasLeadingComment {
   type: 'VExpressionContainer';
   parent: VDocumentFragment | VElement | VDirective | VDirectiveKey;
   expression:
@@ -248,7 +265,7 @@ export interface VDirective extends HasParent {
  * Start tag nodes.
  * @public
  */
-export interface VStartTag extends HasParent {
+export interface VStartTag extends HasParent, HasLeadingComment {
   type: 'VStartTag';
   parent: VElement;
   selfClosing: boolean;
@@ -259,7 +276,7 @@ export interface VStartTag extends HasParent {
  * End tag nodes.
  * @public
  */
-export interface VEndTag extends HasParent {
+export interface VEndTag extends HasParent, HasLeadingComment {
   type: 'VEndTag';
   parent: VElement;
 }
@@ -277,7 +294,6 @@ export interface VElement extends HasParent {
   startTag: VStartTag;
   children: (VElement | VText | VExpressionContainer)[];
   endTag: VEndTag | null;
-
 }
 
 /**

--- a/src/builders.ts
+++ b/src/builders.ts
@@ -109,12 +109,14 @@ export function vDocumentFragment(
 
 /**
  * Creates a new VEndTag node
+ * @param leadingComment - A HTML comment directly before the end tag, if any
  * @returns A new VEndTag node
  * @public
  */
-export function vEndTag(): AST.VEndTag {
+export function vEndTag(leadingComment?: AST.HtmlComment): AST.VEndTag {
   return {
     type: 'VEndTag',
+    leadingComment: leadingComment ?? null,
     // @ts-expect-error Parent is not known yet
     parent: undefined,
   };
@@ -151,14 +153,19 @@ export function vElement(
 /**
  * Creates a new VExpressionContainer node
  * @param expression - The expression in the container
+ * @param leadingComment - If the VExpressionContainer is a child of a VElement, a HTML comment to print directly before this node, if any
  * @returns A new VExpressionContainer node
  * @public
  */
-export function vExpressionContainer(expression: AST.VExpressionContainer['expression']): AST.VExpressionContainer {
+export function vExpressionContainer(
+  expression: AST.VExpressionContainer['expression'],
+  leadingComment?: AST.HtmlComment,
+): AST.VExpressionContainer {
   return {
     type: 'VExpressionContainer',
     references: [],
     expression,
+    leadingComment: leadingComment ?? null,
 
     // @ts-expect-error Parent is not known yet
     parent: undefined,
@@ -231,12 +238,14 @@ export function vLiteral(
  * Creates a new VStartTag node
  * @param attributes - Attributes or Directives
  * @param selfClosing - Whether the tag is self-closing. Void elements should not be self-closing
+ * @param leadingComment - A HTML comment to print directly before the start tag, if any
  * @returns A new VStartTag node
  * @public
  */
 export function vStartTag(
   attributes: AST.VStartTag['attributes'],
   selfClosing: AST.VStartTag['selfClosing'],
+  leadingComment?: AST.HtmlComment,
 ): AST.VStartTag {
   return {
     type: 'VStartTag',
@@ -244,23 +253,27 @@ export function vStartTag(
     // @ts-expect-error Parent is not known yet
     parent: undefined,
     selfClosing,
+    leadingComment: leadingComment ?? null,
   };
 }
 
 /**
  * Create a new VText node
  * @param value - Text value
+ * @param leadingComment - A HTML comment directly before the VText, if any
  * @returns A new VText node
  * @public
  */
 export function vText(
   value: AST.VText['value'],
+  leadingComment?: AST.HtmlComment,
 ): AST.VText {
   return {
     type: 'VText',
     // @ts-expect-error Parent is not known yet
     parent: undefined,
     value,
+    leadingComment: leadingComment ?? null,
   };
 }
 
@@ -316,5 +329,23 @@ export function vFilter(
     callee,
     // @ts-expect-error Parent is not known yet
     parent: undefined,
+  };
+}
+
+/**
+ * Creates a new HtmlComment
+ * @param value The comment's inner value
+ * @param leadingComment Any comment directly before this one
+ * @public
+ */
+export function htmlComment(
+  value: string,
+  leadingComment?: AST.HtmlComment,
+): AST.HtmlComment {
+  return {
+    type: 'HtmlComment',
+    value,
+    leadingComment: leadingComment ?? null,
+    range: [-1, -1],
   };
 }

--- a/src/manual.ts
+++ b/src/manual.ts
@@ -155,7 +155,7 @@ export function findManualMigrations(
   if (filename.endsWith('.vue')) {
     const { scriptASTs: scriptAsts, sfcAST: vueAst, styleASTs } = parseVue(code);
     scripts = scriptAsts;
-    template = vueAst.templateBody!.parent as AST.VDocumentFragment;
+    template = vueAst.templateBody!.parent as unknown as AST.VDocumentFragment;
     styles = styleASTs;
   } else if (getCssDialectForFilename(filename)) {
     styles = [parseCss(code, getCssDialectForFilename(filename)!)];

--- a/src/parse/vue.spec.ts
+++ b/src/parse/vue.spec.ts
@@ -38,4 +38,31 @@ describe('parseVue', () => {
     const ast = parseVue('<script>/* <template> tags are overrated */ export default {} </script>');
     expect(ast.sfcAST).toBeDefined();
   });
+
+  it('should parse comments', () => {
+    const ast = parseVue(`
+<template><!-- before VText -->
+  <!-- before VStartTag --><div>
+    Foo <!-- before VExpressionContainer -->{{ bar }}
+  <!-- before VEndTag --></div>
+</template>
+`);
+    expect(findFirst(ast.sfcAST.templateBody as never, {
+      type: 'VText',
+    })?.leadingComment?.value).toBe(' before VText ');
+
+    expect(findFirst(ast.sfcAST.templateBody as never, {
+      type: 'VElement',
+      name: 'div',
+    })?.startTag.leadingComment?.value).toBe(' before VStartTag ');
+
+    expect(findFirst(ast.sfcAST.templateBody as never, {
+      type: 'VExpressionContainer',
+    })?.leadingComment?.value).toBe(' before VExpressionContainer ');
+
+    expect(findFirst(ast.sfcAST.templateBody as never, {
+      type: 'VElement',
+      name: 'div',
+    })?.endTag?.leadingComment?.value).toBe(' before VEndTag ');
+  });
 });

--- a/src/stringify.spec.ts
+++ b/src/stringify.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { builders as b } from 'ast-types-x';
 import * as builders from './builders';
-import { stringify } from './stringify';
+import { stringify, stringifyHtmlComment } from './stringify';
 
 describe('VEndTag', () => {
   it('should print an empty string', () => {
@@ -236,5 +236,28 @@ describe('VFilterSequenceExpression', () => {
     );
 
     expect(stringify(filter)).toBe('myValue | myFilter(arg1, arg2) | myOtherFilter');
+  });
+});
+
+describe('HtmlComment', () => {
+  it('should print an empty string if null', () => {
+    expect(stringifyHtmlComment(null)).toBe('');
+  });
+
+  it('should print a single comment', () => {
+    const comment = builders.htmlComment(' A comment ');
+    expect(stringifyHtmlComment(comment)).toBe('<!-- A comment -->');
+  });
+
+  it('should print all comments', () => {
+    const comment = builders.htmlComment(
+      ' 1 ',
+      builders.htmlComment(
+        ' 2 ',
+        builders.htmlComment(' 3 '),
+      ),
+    );
+
+    expect(stringifyHtmlComment(comment)).toBe('<!-- 3 --><!-- 2 --><!-- 1 -->');
   });
 });

--- a/src/transform.spec.ts
+++ b/src/transform.spec.ts
@@ -7,13 +7,15 @@ const example = `
 <template>
   <div>
     <custom />
-    <span v-if="hello">
+    <span v-if="hello"><!-- 1 comment -->
+      <!-- 2 comment -->
       <em>Hi there</em>
+      <!-- 3 comment --><!-- 4 comment -->
       {{ value | someFilter | otherFilter }}
       <div v-for="(item, index) in someArray">
-        {{ item | myFilter(arg1) }}
+        <!-- 5 comment -->{{ item | myFilter(arg1) }}
       </div>
-    </span>
+    <!-- 6 comment --></span>
   </div>
 </template>
 <script setup lang="ts" generic="T extends string">
@@ -204,13 +206,15 @@ describe('transform', () => {
       <template>
         <strong hi>
           <custom></custom>
-          <span v-if="hello">
+          <span v-if="hello"><!-- 1 comment -->
+            <!-- 2 comment -->
             <em>Hi there</em>
+            <!-- 3 comment --><!-- 4 comment -->
             {{ value | someFilter | otherFilter }}
             <strong v-for="(item, index) in someArray" hi>
-              {{ item | myFilter(arg1) }}
+              <!-- 5 comment -->{{ item | myFilter(arg1) }}
             </strong>
-          </span>
+          <!-- 6 comment --></span>
         </strong>
       </template>
       <script setup lang="ts" generic="T extends string" setup>

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -61,7 +61,7 @@ function transformVueFile(
 
   const ms = new MagicString(workingCode);
   const { scriptASTs, sfcAST, styleASTs } = parseVue(workingCode);
-  const templateAst = sfcAST.templateBody?.parent as VDocumentFragment;
+  const templateAst = sfcAST.templateBody?.parent as unknown as VDocumentFragment;
   const originalTemplate = cloneDeep(templateAst);
 
   for (const codemod of codemods) {


### PR DESCRIPTION
Fixes HTML comments being lost when re-printing some template nodes

This PR adds a `leadingComment` property to several VNode types and support for re-printing comments