### PR TITLE
Refactor transform logic

### DIFF
--- a/src/cli.spec.ts
+++ b/src/cli.spec.ts
@@ -1,0 +1,412 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { promises as fs } from 'fs';
+import { tmpdir } from 'os';
+import path from 'path';
+import type { CodemodPlugin, ManualMigrationPlugin } from './types';
+
+vi.mock('./default-cli-progress-handler', () => ({
+  createDefaultCliProgressHandler: vi.fn(() => vi.fn()),
+}));
+
+const { createVueMetamorphCli } = await import('./cli');
+const { createDefaultCliProgressHandler } = await import('./default-cli-progress-handler');
+
+let tmpDir: string;
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  tmpDir = await fs.mkdtemp(path.join(tmpdir(), 'vmm-cli-spec-'));
+});
+
+afterEach(async () => {
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+const writeFile = async (rel: string, contents: string) => {
+  const full = path.join(tmpDir, rel);
+  await fs.mkdir(path.dirname(full), { recursive: true });
+  await fs.writeFile(full, contents);
+  return full;
+};
+
+const argv = (...args: string[]) => ['node', 'cli', ...args];
+
+const lastProgressCall = (onProgress: ReturnType<typeof vi.fn>) =>
+  onProgress.mock.calls.at(-1)![0] as {
+    totalFiles: number;
+    filesProcessed: number;
+    filesRemaining: number;
+    aborted: boolean;
+    done: boolean;
+    stats: Record<string, number>;
+    errors: { filename: string; error: Error }[];
+    manualMigrations: { file: string; pluginName: string }[];
+  };
+
+describe('createVueMetamorphCli', () => {
+  describe('file globbing', () => {
+    it('only picks up files with supported extensions', async () => {
+      await writeFile('a.vue', '<template><div /></template>');
+      await writeFile('b.ts', 'const x = 1;');
+      await writeFile('c.css', '.foo { color: red; }');
+      await writeFile('d.md', '# ignored');
+      await writeFile('e.json', '{}');
+
+      const seen: string[] = [];
+      const plugin: CodemodPlugin = {
+        type: 'codemod',
+        name: 'collect',
+        transform({ filename }) {
+          seen.push(path.basename(filename));
+          return 0;
+        },
+      };
+
+      const onProgress = vi.fn();
+      const { run } = createVueMetamorphCli({ plugins: [plugin], silent: true, onProgress });
+      await run(argv('--files', `${tmpDir}/**/*`));
+
+      expect(seen.sort()).toEqual(['a.vue', 'b.ts', 'c.css']);
+      expect(lastProgressCall(onProgress).totalFiles).toBe(3);
+    });
+
+    it('ignores files under node_modules', async () => {
+      await writeFile('keep.ts', 'const x = 1;');
+      await writeFile('node_modules/pkg/index.ts', 'const x = 1;');
+
+      const seen: string[] = [];
+      const plugin: CodemodPlugin = {
+        type: 'codemod',
+        name: 'collect',
+        transform({ filename }) {
+          seen.push(filename);
+          return 0;
+        },
+      };
+
+      const { run } = createVueMetamorphCli({ plugins: [plugin], silent: true });
+      await run(argv('--files', `${tmpDir}/**/*`));
+
+      expect(seen).toHaveLength(1);
+      expect(seen[0]).toMatch(/keep\.ts$/);
+    });
+  });
+
+  describe('--list-plugins', () => {
+    it('prints plugin names and exits', async () => {
+      const writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+      const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+        throw new Error('__exit__');
+      });
+
+      const plugins: CodemodPlugin[] = [
+        { type: 'codemod', name: 'one', transform: () => 0 },
+        { type: 'codemod', name: 'two', transform: () => 0 },
+      ];
+      const { run } = createVueMetamorphCli({ plugins, silent: true });
+
+      await expect(run(argv('--files', `${tmpDir}/**/*`, '--list-plugins'))).rejects.toThrow(
+        '__exit__',
+      );
+      expect(writeSpy).toHaveBeenCalledWith('one\ntwo\n');
+      expect(exitSpy).toHaveBeenCalledWith(0);
+
+      writeSpy.mockRestore();
+      exitSpy.mockRestore();
+    });
+  });
+
+  describe('--plugins filter', () => {
+    it('uses micromatch against plugin names', async () => {
+      await writeFile('a.ts', 'const x = 1;');
+
+      const calls: string[] = [];
+      const mk = (name: string): CodemodPlugin => ({
+        type: 'codemod',
+        name,
+        transform: () => {
+          calls.push(name);
+          return 0;
+        },
+      });
+
+      const { run } = createVueMetamorphCli({
+        plugins: [mk('foo-one'), mk('foo-two'), mk('bar-one')],
+        silent: true,
+      });
+      await run(argv('--files', `${tmpDir}/**/*`, '--plugins', 'foo-*'));
+
+      expect(calls.sort()).toEqual(['foo-one', 'foo-two']);
+    });
+  });
+
+  describe('plugin type routing', () => {
+    it('routes codemod and manual plugins by type', async () => {
+      await writeFile('a.ts', 'const greeting = "before";');
+
+      const manualCalls: string[] = [];
+      const codemod: CodemodPlugin = {
+        type: 'codemod',
+        name: 'rewrite-literal',
+        transform({ scriptASTs, utils: { traverseScriptAST } }) {
+          let count = 0;
+          for (const ast of scriptASTs) {
+            traverseScriptAST(ast, {
+              visitLiteral(p) {
+                if (typeof p.node.value === 'string') {
+                  p.node.value = 'after';
+                  count++;
+                }
+                return this.traverse(p);
+              },
+            });
+          }
+          return count;
+        },
+      };
+
+      const manual: ManualMigrationPlugin = {
+        type: 'manual',
+        name: 'report-literal',
+        find({ scriptASTs, report, utils: { traverseScriptAST } }) {
+          for (const ast of scriptASTs) {
+            traverseScriptAST(ast, {
+              visitLiteral(p) {
+                if (typeof p.node.value === 'string') {
+                  manualCalls.push(String(p.node.value));
+                  report(p.node, 'literal found');
+                }
+                return this.traverse(p);
+              },
+            });
+          }
+        },
+      };
+
+      const onProgress = vi.fn();
+      const { run } = createVueMetamorphCli({
+        plugins: [codemod, manual],
+        silent: true,
+        onProgress,
+      });
+      await run(argv('--files', `${tmpDir}/**/*`));
+
+      const written = await fs.readFile(path.join(tmpDir, 'a.ts'), 'utf-8');
+      expect(written).toContain("'after'");
+      expect(manualCalls).toEqual(['after']);
+      const final = lastProgressCall(onProgress);
+      expect(final.manualMigrations).toHaveLength(1);
+      expect(final.manualMigrations[0]!.pluginName).toBe('report-literal');
+    });
+  });
+
+  describe('plugin array flattening', () => {
+    it('flattens nested plugin arrays', async () => {
+      await writeFile('a.ts', 'const x = 1;');
+
+      const seen: string[] = [];
+      const mk = (name: string): CodemodPlugin => ({
+        type: 'codemod',
+        name,
+        transform: () => {
+          seen.push(name);
+          return 0;
+        },
+      });
+
+      const { run } = createVueMetamorphCli({
+        plugins: [[mk('a'), mk('b')], mk('c')],
+        silent: true,
+      });
+      await run(argv('--files', `${tmpDir}/**/*`));
+
+      expect(seen.sort()).toEqual(['a', 'b', 'c']);
+    });
+  });
+
+  describe('error handling', () => {
+    it('captures plugin errors without killing the run', async () => {
+      await writeFile('a.ts', 'const x = 1;');
+      await writeFile('b.ts', 'const y = 2;');
+
+      let calls = 0;
+      const plugin: CodemodPlugin = {
+        type: 'codemod',
+        name: 'sometimes-throws',
+        transform({ filename }) {
+          calls++;
+          if (filename.endsWith('a.ts')) {
+            throw new Error('boom');
+          }
+          return 0;
+        },
+      };
+
+      const onProgress = vi.fn();
+      const { run } = createVueMetamorphCli({ plugins: [plugin], silent: true, onProgress });
+      await run(argv('--files', `${tmpDir}/**/*`));
+
+      expect(calls).toBe(2);
+      const final = lastProgressCall(onProgress);
+      expect(final.done).toBe(true);
+      expect(final.errors).toHaveLength(1);
+      expect(final.errors[0]!.error.message).toBe('boom');
+      expect(final.errors[0]!.filename).toMatch(/a\.ts$/);
+    });
+  });
+
+  describe('abort()', () => {
+    it('stops processing before the next file', async () => {
+      await writeFile('a.ts', 'const x = 1;');
+      await writeFile('b.ts', 'const y = 2;');
+      await writeFile('c.ts', 'const z = 3;');
+
+      let abortFn: (() => void) | null = null;
+      let calls = 0;
+      const plugin: CodemodPlugin = {
+        type: 'codemod',
+        name: 'self-abort',
+        transform() {
+          calls++;
+          abortFn!();
+          return 0;
+        },
+      };
+
+      const onProgress = vi.fn();
+      const cli = createVueMetamorphCli({ plugins: [plugin], silent: true, onProgress });
+      abortFn = cli.abort;
+      await cli.run(argv('--files', `${tmpDir}/**/*`));
+
+      expect(calls).toBe(1);
+      const final = lastProgressCall(onProgress);
+      expect(final.aborted).toBe(true);
+      expect(final.done).toBe(false);
+    });
+  });
+
+  describe('progress callback', () => {
+    it('reports done: true in the final event of a normal run', async () => {
+      await writeFile('a.ts', 'const x = 1;');
+      await writeFile('b.ts', 'const y = 2;');
+
+      const onProgress = vi.fn();
+      const plugin: CodemodPlugin = { type: 'codemod', name: 'noop', transform: () => 0 };
+      const { run } = createVueMetamorphCli({ plugins: [plugin], silent: true, onProgress });
+      await run(argv('--files', `${tmpDir}/**/*`));
+
+      const final = lastProgressCall(onProgress);
+      expect(final.done).toBe(true);
+      expect(final.aborted).toBe(false);
+      expect(final.filesProcessed).toBe(2);
+      expect(final.filesRemaining).toBe(0);
+      expect(final.totalFiles).toBe(2);
+    });
+
+    it('accumulates per-plugin stats across files', async () => {
+      await writeFile('a.ts', 'const x = 1;');
+      await writeFile('b.ts', 'const y = 2;');
+
+      const plugin: CodemodPlugin = {
+        type: 'codemod',
+        name: 'counter',
+        transform: () => 3,
+      };
+
+      const onProgress = vi.fn();
+      const { run } = createVueMetamorphCli({ plugins: [plugin], silent: true, onProgress });
+      await run(argv('--files', `${tmpDir}/**/*`));
+
+      expect(lastProgressCall(onProgress).stats).toEqual({ counter: 6 });
+    });
+  });
+
+  describe('silent option', () => {
+    it('skips the default progress handler when silent: true', async () => {
+      await writeFile('a.ts', 'const x = 1;');
+
+      const defaultHandler = vi.fn();
+      vi.mocked(createDefaultCliProgressHandler).mockReturnValue(defaultHandler);
+
+      const onProgress = vi.fn();
+      const plugin: CodemodPlugin = { type: 'codemod', name: 'noop', transform: () => 0 };
+      const { run } = createVueMetamorphCli({ plugins: [plugin], silent: true, onProgress });
+      await run(argv('--files', `${tmpDir}/**/*`));
+
+      expect(defaultHandler).not.toHaveBeenCalled();
+      expect(onProgress).toHaveBeenCalled();
+    });
+
+    it('invokes the default progress handler when silent is not set', async () => {
+      await writeFile('a.ts', 'const x = 1;');
+
+      const defaultHandler = vi.fn();
+      vi.mocked(createDefaultCliProgressHandler).mockReturnValue(defaultHandler);
+
+      const plugin: CodemodPlugin = { type: 'codemod', name: 'noop', transform: () => 0 };
+      const { run } = createVueMetamorphCli({ plugins: [plugin] });
+      await run(argv('--files', `${tmpDir}/**/*`));
+
+      expect(defaultHandler).toHaveBeenCalled();
+    });
+  });
+
+  describe('file writing', () => {
+    it('writes a file when a codemod reports count > 0', async () => {
+      const filePath = await writeFile('a.ts', 'const greeting = "before";');
+
+      const plugin: CodemodPlugin = {
+        type: 'codemod',
+        name: 'rewrite',
+        transform({ scriptASTs, utils: { traverseScriptAST } }) {
+          let count = 0;
+          for (const ast of scriptASTs) {
+            traverseScriptAST(ast, {
+              visitLiteral(p) {
+                if (typeof p.node.value === 'string') {
+                  p.node.value = 'after';
+                  count++;
+                }
+                return this.traverse(p);
+              },
+            });
+          }
+          return count;
+        },
+      };
+
+      const { run } = createVueMetamorphCli({ plugins: [plugin], silent: true });
+      await run(argv('--files', `${tmpDir}/**/*`));
+
+      expect(await fs.readFile(filePath, 'utf-8')).toContain("'after'");
+    });
+
+    it('does not write a file when every codemod returns 0', async () => {
+      const filePath = await writeFile('a.ts', 'const x = 1;');
+      const before = await fs.stat(filePath);
+
+      const plugin: CodemodPlugin = { type: 'codemod', name: 'noop', transform: () => 0 };
+      const { run } = createVueMetamorphCli({ plugins: [plugin], silent: true });
+      await run(argv('--files', `${tmpDir}/**/*`));
+
+      const after = await fs.stat(filePath);
+      expect(after.mtimeMs).toBe(before.mtimeMs);
+    });
+  });
+
+  describe('additionalCliOptions', () => {
+    it('exposes user-defined options via opts()', async () => {
+      const cli = createVueMetamorphCli({
+        plugins: [],
+        silent: true,
+        additionalCliOptions(program) {
+          program.option('--flavor <name>', 'pick a flavor');
+        },
+      });
+
+      expect(cli.opts(argv('--files', `${tmpDir}/**/*`, '--flavor', 'vanilla'))).toMatchObject({
+        flavor: 'vanilla',
+      });
+    });
+  });
+});

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -1,9 +1,10 @@
 import MagicString from 'magic-string';
 import { cloneDeep, get, uniqWith, isEqual } from 'lodash-es';
 import * as recast from 'recast-x';
+import type postcss from 'postcss';
 import deepDiff from './vendor/deep-diff/index.js';
 import * as AST from './ast';
-import { utils, type CodemodPlugin } from './types';
+import { utils, type CodemodPlugin, type VueProgram } from './types';
 import { setParents, vText } from './builders';
 import { stringify } from './stringify';
 import { parseTs, parseVue } from './parse';
@@ -31,6 +32,16 @@ const ignoreProperties: Record<string, true> = {
   references: true,
 };
 
+const NON_RENDERABLE_TYPES = new Set<string>([
+  'VStartTag', // VStartTag is rendered as part of VElement, not by itself
+  'VExpressionContainer', // VExpressionContainer has wrong locations from vue-eslint-parser sometimes
+]);
+
+const NON_RENDERABLE_AS_CHILD_OF = new Set<string>([
+  'VDirectiveKey', // range includes the 'v-' prefix
+  'VExpressionContainer', // VExpressionContainer has wrong locations from vue-eslint-parser, so all of its children could as well
+]);
+
 /**
  * Return type of the `transform` function, containing new source code and codemod stats
  * @public
@@ -47,6 +58,59 @@ export type TransformResult = {
   stats: [codemodName: string, transformCount: number][];
 };
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type RenderableNode = { type: string; range: [number, number] } & Record<string, any>;
+
+function isNode(value: unknown): value is RenderableNode {
+  return !!value && typeof value === 'object' && 'type' in value;
+}
+
+/**
+ * Walk up a diff property-path until we land on a node that prints as a
+ * self-contained unit with a correct range. Non-node segments (arrays,
+ * primitives) and `NON_RENDERABLE_TYPES` are skipped automatically.
+ */
+function findRenderableNode(
+  root: AST.Node,
+  propertyPath: (string | number)[],
+): { path: (string | number)[]; node: RenderableNode } {
+  // Drop the trailing property name so we're pointing at the owning node.
+  let path = propertyPath.slice(0, -1);
+  while (path.length > 0) {
+    const value = get(root, path);
+    if (isNode(value) && !NON_RENDERABLE_TYPES.has(value.type)) {
+      const parentPath = path.slice(0, -1);
+      const parent = parentPath.length > 0 ? get(root, parentPath) : root;
+      const blockedByParent = isNode(parent) && NON_RENDERABLE_AS_CHILD_OF.has(parent.type);
+      if (!blockedByParent) {
+        return { path, node: value };
+      }
+    }
+    path = path.slice(0, -1);
+  }
+  return {
+    path,
+    node: root as RenderableNode,
+  };
+}
+
+function runCodemods(
+  codemods: CodemodPlugin[],
+  filename: string,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  opts: Record<string, any>,
+  asts: {
+    scriptASTs: VueProgram[];
+    sfcAST: AST.VDocumentFragment | null;
+    styleASTs: postcss.Root[];
+  },
+): [string, number][] {
+  return codemods.map((codemod) => [
+    codemod.name,
+    codemod.transform({ ...asts, filename, utils, opts }),
+  ]);
+}
+
 function transformVueFile(
   code: string,
   filename: string,
@@ -54,10 +118,7 @@ function transformVueFile(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   opts: Record<string, any>,
 ): TransformResult {
-  const workingCode = code;
-  const stats: [string, number][] = [];
-
-  const ms = new MagicString(workingCode);
+  const ms = new MagicString(code);
   const {
     scriptASTs,
     sfcAST,
@@ -67,191 +128,157 @@ function transformVueFile(
     originalScripts,
     originalStyles,
     neededExtraTemplate,
-  } = parseVue(workingCode);
+  } = parseVue(code);
   const originalScriptCount = scriptASTMap.size;
   const originalStyleCount = styleASTMap.size;
   const templateAst = sfcAST.templateBody?.parent as unknown as VDocumentFragment;
   const originalTemplate = cloneDeep(templateAst);
 
-  for (const codemod of codemods) {
-    const count = codemod.transform({
-      scriptASTs,
-      sfcAST: templateAst ?? null,
-      styleASTs,
-      filename,
-      utils,
-      opts,
-    });
+  const stats = runCodemods(codemods, filename, opts, {
+    scriptASTs,
+    sfcAST: templateAst ?? null,
+    styleASTs,
+  });
 
-    stats.push([codemod.name, count]);
+  if (!templateAst || !originalTemplate) {
+    return { code: ms.toString(), stats };
   }
 
-  if (templateAst && originalTemplate) {
-    setParents(templateAst);
+  setParents(templateAst);
 
-    let nextExtraScript = originalScriptCount;
-    let nextExtraStyle = originalStyleCount;
-    AST.traverseNodes(templateAst as never, {
-      enterNode(node) {
-        if (node.type === 'VElement' && node.name === 'script' && node.parent === templateAst) {
-          let scriptAst = scriptASTMap.get(node as never);
-          if (
-            !scriptAst &&
-            !originalScripts.has(node as never) &&
-            nextExtraScript < scriptASTs.length
-          ) {
-            scriptAst = scriptASTs[nextExtraScript++];
-          }
-          if (scriptAst) {
-            const newCode = recast
-              .print(scriptAst, recastOptions)
-              .code.replace(/\/\* METAMORPH_START \*\/(\r?\n)*/g, '\n');
+  let nextExtraScript = originalScriptCount;
+  let nextExtraStyle = originalStyleCount;
 
-            const text = `${newCode.startsWith('\n') ? '' : '\n'}${newCode}\n`;
-            if (node.children[0]?.type === 'VText') {
-              node.children[0].value = text;
-            } else {
-              node.children.unshift(vText(text));
-            }
-          }
-        }
+  const reprintScriptBlock = (node: AST.VElement) => {
+    if (node.name !== 'script' || node.parent !== templateAst) return;
 
-        if (
-          node.type === 'VElement' &&
-          node.name === 'style' &&
-          node.parent === templateAst &&
-          isSupportedLang(getLangAttribute(node)) &&
-          node.children[0]?.type === 'VText'
-        ) {
-          let styleAst = styleASTMap.get(node as never);
-          if (
-            !styleAst &&
-            !originalStyles.has(node as never) &&
-            nextExtraStyle < styleASTs.length
-          ) {
-            styleAst = styleASTs[nextExtraStyle++];
-          }
-          if (styleAst) {
-            const newCode = styleAst
-              .toString(syntaxMap[getLangAttribute(node)]!.stringify)
-              .replace(/\/\* METAMORPH_START \*\/(\r?\n)*/g, '\n');
-
-            node.children.length = 0;
-            node.children.push(vText(`${newCode.startsWith('\n') ? '' : '\n'}${newCode}`));
-          }
-        }
-      },
-      leaveNode() {
-        // empty
-      },
-    });
-
-    const diff = deepDiff(originalTemplate, templateAst, (_, name) => !!ignoreProperties[name]);
-
-    if (diff) {
-      let rootNodeChanged = false;
-
-      type ChangedNode = {
-        path: (string | number)[];
-        node: AST.Node;
-        start: number;
-        end: number;
-      };
-
-      const changedNodes: ChangedNode[] = diff.map((p) => {
-        const path = [...(p.path ?? [])];
-
-        // we want the path to the node, not the path to the changed property
-        path.pop();
-
-        // special case: the VStartTag doesn't actually render a full tag
-        if (path.at(-1) === 'startTag') {
-          path.pop();
-        }
-
-        // special case: VDirectiveKey.key's range includes the 'v-' prefix
-        if (path.at(-2) === 'key') {
-          path.pop();
-        }
-
-        // vue-eslint-parser has wrong location for VExpressionContainer sometimes
-        // just render whole tag again as a workaround
-        if (path.at(-1) === 'expression') {
-          path.pop();
-          path.pop();
-        }
-
-        if (path.at(-1) === 'body') {
-          path.pop();
-        }
-
-        if (path.at(-1) === 'children') {
-          path.pop();
-        }
-
-        if (path.length <= 3 && p.kind !== 'E') {
-          // adding/removing children from the root node should cause a re-print of the root
-          rootNodeChanged = true;
-        }
-
-        const originalNode = rootNodeChanged ? originalTemplate : get(originalTemplate, path);
-
-        return {
-          path,
-          start: originalNode.range[0],
-          end: originalNode.range[1],
-          node: path.length === 0 ? templateAst : get(templateAst, path),
-        };
-      });
-
-      if (rootNodeChanged) {
-        if (neededExtraTemplate) {
-          templateAst.children = templateAst.children.filter(
-            (el) => el.type !== 'VElement' || el.name !== 'template',
-          );
-        }
-        // the 'range' property is present, though the types don't include it for DX
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const [start, end] = (originalTemplate as any).range;
-
-        ms.update(start, end, stringify(templateAst));
-      } else {
-        /* Collapse the diff results. If two changed paths are
-          ['children', 1, 'children', 2]
-          ['children', 1]
-
-          We don't need to worry about the deeper changed node since one of its ancestors
-          has changed and the deeper node's changes will be printed anyways.
-
-          Sort ascending by path length first: uniqWith keeps the first occurrence
-          and drops later matches, so the shorter (ancestor) path needs to land in
-          the array before any of its descendants.
-        */
-        const collapsedChanges = uniqWith(
-          [...changedNodes].sort((a, b) => a.path.length - b.path.length),
-          (a: ChangedNode, b: ChangedNode) => {
-            if (a.path.length === b.path.length) {
-              return isEqual(a.path, b.path);
-            }
-
-            const lesser = a.path.length < b.path.length ? a : b;
-            const greater = lesser === a ? b : a;
-
-            return isEqual(lesser.path, greater.path.slice(0, lesser.path.length));
-          },
-        ).sort((a, b) => b.path.length - a.path.length);
-
-        for (const { start, end, node } of collapsedChanges) {
-          ms.update(start, end, stringify(node));
-        }
-      }
+    let scriptAst = scriptASTMap.get(node as never);
+    if (!scriptAst && !originalScripts.has(node as never) && nextExtraScript < scriptASTs.length) {
+      scriptAst = scriptASTs[nextExtraScript++];
     }
+    if (!scriptAst) return;
+
+    const newCode = recast
+      .print(scriptAst, recastOptions)
+      .code.replace(/\/\* METAMORPH_START \*\/(\r?\n)*/g, '\n');
+
+    const text = `${newCode.startsWith('\n') ? '' : '\n'}${newCode}\n`;
+    if (node.children[0]?.type === 'VText') {
+      node.children[0].value = text;
+    } else {
+      node.children.unshift(vText(text));
+    }
+  };
+
+  const reprintStyleBlock = (node: AST.VElement) => {
+    if (
+      node.name !== 'style' ||
+      node.parent !== templateAst ||
+      !isSupportedLang(getLangAttribute(node)) ||
+      node.children[0]?.type !== 'VText'
+    ) {
+      return;
+    }
+
+    let styleAst = styleASTMap.get(node as never);
+    if (!styleAst && !originalStyles.has(node as never) && nextExtraStyle < styleASTs.length) {
+      styleAst = styleASTs[nextExtraStyle++];
+    }
+    if (!styleAst) return;
+
+    const newCode = styleAst
+      .toString(syntaxMap[getLangAttribute(node)]!.stringify)
+      .replace(/\/\* METAMORPH_START \*\/(\r?\n)*/g, '\n');
+
+    node.children.length = 0;
+    node.children.push(vText(`${newCode.startsWith('\n') ? '' : '\n'}${newCode}`));
+  };
+
+  AST.traverseNodes(templateAst as never, {
+    enterNode(node) {
+      if (node.type === 'VElement') {
+        reprintScriptBlock(node);
+        reprintStyleBlock(node);
+      }
+    },
+    leaveNode() {
+      // empty
+    },
+  });
+
+  const diff = deepDiff(originalTemplate, templateAst, (_, name) => !!ignoreProperties[name]);
+
+  if (!diff) {
+    return { code: ms.toString(), stats };
   }
 
-  return {
-    code: ms.toString(),
-    stats,
+  const normalized = diff.map((p) => ({
+    diff: p,
+    ...findRenderableNode(originalTemplate, [...(p.path ?? [])]),
+  }));
+
+  // Adding or removing something near the root of the template means the root's
+  // children list has changed, so we re-print the whole template rather than
+  // trying to splice individual nodes.
+  const rootNodeChanged = normalized.some(
+    ({ path, diff: p }) => path.length <= 3 && p.kind !== 'E',
+  );
+
+  if (rootNodeChanged) {
+    if (neededExtraTemplate) {
+      templateAst.children = templateAst.children.filter(
+        (el) => el.type !== 'VElement' || el.name !== 'template',
+      );
+    }
+    // the 'range' property is present, though the types don't include it for DX
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const [start, end] = (originalTemplate as any).range;
+    ms.update(start, end, stringify(templateAst));
+    return { code: ms.toString(), stats };
+  }
+
+  type ChangedNode = {
+    path: (string | number)[];
+    node: AST.Node;
+    start: number;
+    end: number;
   };
+
+  const changedNodes: ChangedNode[] = normalized.map(({ path, node: originalNode }) => ({
+    path,
+    start: originalNode.range[0],
+    end: originalNode.range[1],
+    node: path.length === 0 ? templateAst : get(templateAst, path),
+  }));
+
+  /* Collapse the diff results. If two changed paths are
+    ['children', 1, 'children', 2]
+    ['children', 1]
+
+    We don't need to worry about the deeper changed node since one of its ancestors
+    has changed and the deeper node's changes will be printed anyways.
+
+    Sort ascending by path length first: uniqWith keeps the first occurrence
+    and drops later matches, so the shorter (ancestor) path needs to land in
+    the array before any of its descendants.
+  */
+  const collapsedChanges = uniqWith(
+    [...changedNodes].sort((a, b) => a.path.length - b.path.length),
+    (a, b) => {
+      if (a.path.length === b.path.length) {
+        return isEqual(a.path, b.path);
+      }
+      const lesser = a.path.length < b.path.length ? a : b;
+      const greater = lesser === a ? b : a;
+      return isEqual(lesser.path, greater.path.slice(0, lesser.path.length));
+    },
+  ).sort((a, b) => b.path.length - a.path.length);
+
+  for (const { start, end, node } of collapsedChanges) {
+    ms.update(start, end, stringify(node));
+  }
+
+  return { code: ms.toString(), stats };
 }
 
 function transformTypescriptFile(
@@ -262,19 +289,11 @@ function transformTypescriptFile(
   opts: Record<string, any>,
 ): TransformResult {
   const ast = parseTs(code, /\.[jt]sx$/.test(filename));
-  const stats: [string, number][] = [];
-
-  for (const codemod of codemods) {
-    const count = codemod.transform({
-      scriptASTs: [ast],
-      sfcAST: null,
-      styleASTs: [],
-      filename,
-      utils,
-      opts,
-    });
-    stats.push([codemod.name, count]);
-  }
+  const stats = runCodemods(codemods, filename, opts, {
+    scriptASTs: [ast],
+    sfcAST: null,
+    styleASTs: [],
+  });
 
   return {
     code: `${recast.print(ast, recastOptions).code}\n`,
@@ -288,30 +307,19 @@ function transformCssFile(
   codemods: CodemodPlugin[],
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   opts: Record<string, any>,
-) {
+): TransformResult {
   const dialect = getCssDialectForFilename(filename);
 
   if (!dialect) {
-    return {
-      code,
-      stats: [],
-    };
+    return { code, stats: [] };
   }
+
   const ast = parseCss(code, dialect);
-  const stats: [string, number][] = [];
-
-  for (const codemod of codemods) {
-    const count = codemod.transform({
-      scriptASTs: [],
-      sfcAST: null,
-      styleASTs: [ast],
-      filename,
-      utils,
-      opts,
-    });
-
-    stats.push([codemod.name, count]);
-  }
+  const stats = runCodemods(codemods, filename, opts, {
+    scriptASTs: [],
+    sfcAST: null,
+    styleASTs: [ast],
+  });
 
   return {
     code: ast.toString(syntaxMap[dialect]),


### PR DESCRIPTION
- Refactors transform logic to be simpler / removes the `path.pop()` hacks that were hard to reason about
- Adds missing tests for cli.ts