### PR TITLE
allow re-running aborted cli instance

### DIFF
--- a/src/cli.spec.ts
+++ b/src/cli.spec.ts
@@ -283,6 +283,36 @@ describe('createVueMetamorphCli', () => {
       expect(final.aborted).toBe(true);
       expect(final.done).toBe(false);
     });
+
+    it('can run again after a previous run was aborted', async () => {
+      await writeFile('a.ts', 'const x = 1;');
+      await writeFile('b.ts', 'const y = 2;');
+
+      let abortFn: (() => void) | null = null;
+      let calls = 0;
+      const plugin: CodemodPlugin = {
+        type: 'codemod',
+        name: 'maybe-abort',
+        transform() {
+          calls++;
+          if (calls === 1) abortFn!();
+          return 0;
+        },
+      };
+
+      const onProgress = vi.fn();
+      const cli = createVueMetamorphCli({ plugins: [plugin], silent: true, onProgress });
+      abortFn = cli.abort;
+
+      await cli.run(argv('--files', `${tmpDir}/**/*`));
+      expect(lastProgressCall(onProgress).aborted).toBe(true);
+
+      await cli.run(argv('--files', `${tmpDir}/**/*`));
+      const second = lastProgressCall(onProgress);
+      expect(second.aborted).toBe(false);
+      expect(second.done).toBe(true);
+      expect(second.filesProcessed).toBe(2);
+    });
   });
 
   describe('progress callback', () => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -141,6 +141,7 @@ export function createVueMetamorphCli(options: CreateVueMetamorphCliOptions) {
   let aborted = false;
 
   const run = async (argv = process.argv) => {
+    aborted = false;
     program.parse(argv);
     const opts = program.opts<ProgramOptions>();
     const stats: Record<string, number> = {};


### PR DESCRIPTION
currently, aborted cli instances must be re-instantiated. This change resets the aborted flag so that an aborted instance can be re-run again without needing re-instantiation