### PR TITLE
fix case where quotes are not escaped

### DIFF
--- a/src/stringify.spec.ts
+++ b/src/stringify.spec.ts
@@ -145,6 +145,15 @@ describe('VAttribute', () => {
 
       expect(stringify(node)).toBe('title="she said &quot;hi&quot;"');
     });
+
+    it('should escape double quotes in a directive expression value', () => {
+      const node = builders.vDirective(
+        builders.vDirectiveKey(builders.vIdentifier('bind', ':'), builders.vIdentifier('title')),
+        builders.vExpressionContainer(b.literal('she said "hi"')),
+      );
+
+      expect(stringify(node)).toBe(':title="\'she said &quot;hi&quot;\'"');
+    });
   });
 });
 

--- a/src/stringify.ts
+++ b/src/stringify.ts
@@ -101,7 +101,7 @@ export function stringifyVAttribute(node: AST.VAttribute | AST.VDirective): stri
     if (node.value.type === 'VLiteral') {
       str += `="${escapeAttributeValue(node.value.value)}"`;
     } else {
-      str += `="${stringify(node.value)}"`;
+      str += `="${escapeAttributeValue(stringify(node.value))}"`;
     }
   }
 


### PR DESCRIPTION
when stringifying a JS expression in the body of a directive, there was a case where quotes were not being escaped, which would emit invalid html